### PR TITLE
OverlayManager: allow user to define Overlay z-order

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/MapEventsOverlay.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/MapEventsOverlay.java
@@ -26,6 +26,7 @@ public class MapEventsOverlay extends Overlay {
     public MapEventsOverlay(Context ctx, MapEventsReceiver receiver) {
         super(ctx);
         mReceiver = receiver;
+        setOverlayIndex(0);
     }
 
     @Override

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/Overlay.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/Overlay.java
@@ -26,12 +26,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author Nicolas Gramlich
  */
 public abstract class Overlay {
-
     private static AtomicInteger sOrdinal = new AtomicInteger();
 
     protected float mScale;
     private static final Rect mRect = new Rect();
     private boolean mEnabled = true;
+    private int mOverlayIndex = 3;
 
     public Overlay() {
     }
@@ -45,6 +45,28 @@ public abstract class Overlay {
     public Overlay setContext(final Context ctx) {
         mScale = ctx.getResources().getDisplayMetrics().density;
         return this;
+    }
+
+    /**
+     * Sets the z position of this layer in the layer stack
+     * larger values for @param layerIndex are drawn on top.
+     *
+     * Default values are:
+     * 0 for MapEventsOverlay
+     * 1 for PathOverlay
+     * 2 for UserLocationOverlay
+     * 3 for other Overlays
+     */
+    public void setOverlayIndex(int overlayIndex) {
+        mOverlayIndex = overlayIndex;
+    }
+
+    /**
+     * Get the z position of this layer in the overlay stack
+     * @return overlay index, larger values are drawn on top
+     */
+    public int getOverlayIndex() {
+        return mOverlayIndex;
     }
 
     /**

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/OverlayManager.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/OverlayManager.java
@@ -71,24 +71,11 @@ public class OverlayManager extends AbstractList<Overlay> {
         }
     }
 
-    private Integer getOverlayClassSortIndex(Overlay overlay) {
-        int result = 3;
-        if (overlay instanceof MapEventsOverlay) {
-            result = 0;
-        } else if (overlay instanceof UserLocationOverlay) {
-            result = 2;
-        } else if (overlay instanceof PathOverlay) {
-            result = 1;
-        }
-        return Integer.valueOf(result);
-    }
-
     private void sortOverlays() {
-
         Overlay[] array = mOverlayList.toArray(new Overlay[mOverlayList.size()]);
         Arrays.sort(array, new Comparator<Overlay>() {
             public int compare(Overlay lhs, Overlay rhs) {
-                return (getOverlayClassSortIndex(lhs).compareTo(getOverlayClassSortIndex(rhs)));
+                return (Integer.valueOf(lhs.getOverlayIndex()).compareTo(rhs.getOverlayIndex()));
             }
         });
         mOverlayList.clear();

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/PathOverlay.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/PathOverlay.java
@@ -53,6 +53,7 @@ public class PathOverlay extends Overlay {
         this.mPaint.setStrokeWidth(10.0f);
         this.mPaint.setStyle(Paint.Style.STROKE);
         this.clearPath();
+        setOverlayIndex(1);
     }
 
     public PathOverlay(final int color, final float width) {
@@ -62,6 +63,7 @@ public class PathOverlay extends Overlay {
         this.mPaint.setStyle(Paint.Style.STROKE);
 
         this.clearPath();
+        setOverlayIndex(1);
     }
 
     public Paint getPaint() {

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/UserLocationOverlay.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/UserLocationOverlay.java
@@ -110,6 +110,7 @@ public class UserLocationOverlay extends SafeDrawOverlay implements Snappable, M
         }
 
         setMyLocationProvider(myLocationProvider);
+        setOverlayIndex(2);
     }
 
     public UserLocationOverlay(GpsLocationProvider myLocationProvider, MapView mapView) {


### PR DESCRIPTION
In the current mapbox releases overlays added by the user are automatically sorted in the OverlayManager, according to a quite arbitrary criterion.

While the documentation for MapView.getOverlays() claims that it allows you to sort Overlays manually, this is not true, as any manual change will be reverted immediately by the sort() call within OverlayManager.

This patch allows users to manually specify a z-index for each overlay he/she creates, by calling overlay.setOverlayIndex(). The default values for the different Overlay types are set such that the order should be the same as for previous mapbox releases.