### PR TITLE
moved cache/data folder and use mUseDataConnection in MapTileDownloader

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTileCache.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTileCache.java
@@ -210,8 +210,8 @@ public class MapTileCache implements TileLayerConstants {
         final String cachePath =
                 Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())
                         || (!Environment.isExternalStorageRemovable())
-                        ? Environment.getExternalStorageDirectory().getPath()
-                        : context.getFilesDir().getPath();
+                        ? context.getExternalCacheDir().getPath()
+                        : context.getCacheDir().getPath();
 
         return new File(cachePath, uniqueName);
     }

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTileLayerArray.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTileLayerArray.java
@@ -103,7 +103,7 @@ public class MapTileLayerArray extends MapTileLayerBase {
      */
     private boolean tileUnavailable(final MapTile pTile) {
         if (mUnaccessibleTiles.size() > 0) {
-            if (networkAvailable()) {
+            if (networkAvailable() || !useDataConnection()) {
                 mUnaccessibleTiles.clear();
             } else if (mUnaccessibleTiles.contains(pTile)) {
                 return true;

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/modules/MapTileDownloader.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/modules/MapTileDownloader.java
@@ -25,6 +25,7 @@ public class MapTileDownloader extends MapTileModuleLayerBase {
     private final AtomicReference<MapTileCache> mTileCache = new AtomicReference<MapTileCache>();
 
     private final NetworkAvailabilityCheck mNetworkAvailabilityCheck;
+    private boolean mUseDataConnection = true;
     private MapView mapView;
     boolean hdpi;
 
@@ -36,6 +37,7 @@ public class MapTileDownloader extends MapTileModuleLayerBase {
 
         hdpi = mapView.getContext().getResources().getDisplayMetrics().densityDpi
                 > DisplayMetrics.DENSITY_HIGH;
+        mUseDataConnection = this.mapView.useDataConnection();
 
         mNetworkAvailabilityCheck = pNetworkAvailabilityCheck;
         setTileSource(pTileSource);
@@ -64,7 +66,7 @@ public class MapTileDownloader extends MapTileModuleLayerBase {
 
     @Override
     public boolean getUsesDataConnection() {
-        return true;
+        return mUseDataConnection;
     }
 
     @Override

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/MBTilesLayer.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/MBTilesLayer.java
@@ -152,8 +152,14 @@ public class MBTilesLayer extends TileLayer implements MapViewConstants, MapboxC
             InputStream inputStream;
             try {
                 inputStream = am.open(url);
-                return createFileFromInputStream(inputStream,
-                        Environment.getExternalStorageDirectory() + File.separator + url);
+                final File mbtilesDir;     
+                if(Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())
+                || (!Environment.isExternalStorageRemovable()){
+                    mbtilesDir = new File(context.getExternalFilesDir(null), url);
+                } else {
+                    mbtilesDir = new File(context.getFilesDir(), url);
+                }
+                return createFileFromInputStream(inputStream, mbtilesDir.getPath());
             } catch (IOException e) {
                 Log.e(TAG, "MBTiles file not found in assets: " + e.toString());
                 return null;

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/MBTilesLayer.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/MBTilesLayer.java
@@ -154,7 +154,7 @@ public class MBTilesLayer extends TileLayer implements MapViewConstants, MapboxC
                 inputStream = am.open(url);
                 final File mbtilesDir;     
                 if(Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())
-                || (!Environment.isExternalStorageRemovable()){
+                    || (!Environment.isExternalStorageRemovable()) {
                     mbtilesDir = new File(context.getExternalFilesDir(null), url);
                 } else {
                     mbtilesDir = new File(context.getFilesDir(), url);


### PR DESCRIPTION
This pull request should fix offline map usage, actually use the mUseDataConnection boolean in the MapTileDownloader to check if a data connection is necessary for the map source to load the map tiles. For instance MBtiles files do not require internet to load the actual map tiles.

Also I moved the maptile disk cache folder from the root internal/external storage to the app cache folder so that it gets deleted once the app deleted. Also Moved the mbtiles file from the root internal/external storage to the app data folder on the internal/external storage so that it is properly deleted when the user deletes the app.