### PR TITLE
Draw loading tiles only for base layer

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/TilesOverlay.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/overlay/TilesOverlay.java
@@ -57,6 +57,7 @@ public class TilesOverlay extends SafeDrawOverlay {
 
     private int mLoadingBackgroundColor = Color.rgb(216, 208, 208);
     private int mLoadingLineColor = Color.rgb(200, 192, 192);
+    private boolean mDrawLoadingTile = false;
 
     public TilesOverlay(final MapTileLayerBase aTileProvider) {
         super();
@@ -142,7 +143,9 @@ public class TilesOverlay extends SafeDrawOverlay {
         // Draw the tiles!
         if (tileSize > 0) {
             Log.d(TAG, "drawSafe(), start drawing tiles!");
-            drawLoadingTile(c.getSafeCanvas(), mapView, zoomLevel, mClipRect);
+            if (mDrawLoadingTile) {
+                drawLoadingTile(c.getSafeCanvas(), mapView, zoomLevel, mClipRect);
+            }
             drawTiles(c.getSafeCanvas(), zoomLevel, tileSize, mViewPort, mClipRect);
             Log.d(TAG, "drawSafe(), done drawing tiles!");
         } else {
@@ -277,6 +280,10 @@ public class TilesOverlay extends SafeDrawOverlay {
             mLoadingPaint.setColor(mLoadingLineColor);
             clearLoadingTile();
         }
+    }
+
+    public void setDrawLoadingTile(final boolean pDrawLoadingTile) {
+        this.mDrawLoadingTile = pDrawLoadingTile;
     }
 
     /**

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -197,6 +197,7 @@ public class MapView extends ViewGroup implements MapViewConstants, MapEventsRec
         mTileProvider.setTileRequestCompleteHandler(mTileRequestCompleteHandler);
 
         mTilesOverlay = new TilesOverlay(mTileProvider);
+        mTilesOverlay.setDrawLoadingTile(true);
         mOverlayManager = new OverlayManager(mTilesOverlay);
 
         this.mGestureDetector =


### PR DESCRIPTION
Draw loading tile only, if drawLoadingTile == true. Allows you to add multiple transparent TileLayers:
mapView.addTileSource(tileLayer1);
MapTileLayerBase mapTileLayerBase = new MapTileLayerBasic(mapView.getContext(), tileLayer2, mapView);
TilesOverlay overlay = new TilesOverlay(mapTileLayerBase);
mapView.getOverlays().add(overlay);

Fixes https://github.com/mapbox/mapbox-android-sdk/issues/572