### PR TITLE
fix mapView redraw callback for async tile loader

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTileLayerBase.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTileLayerBase.java
@@ -171,6 +171,8 @@ public abstract class MapTileLayerBase implements IMapTileProviderCallback, Tile
             msg.obj = pState.getMapTile().getTileRect();
             msg.what = MapTile.MAPTILE_SUCCESS_ID;
             mTileRequestCompleteHandler.sendMessage(msg);
+        } else {
+            Log.e(TAG, "Failed to send map update request because mTileRequestCompleteHandler == null");
         }
 
         if (DEBUG_TILE_PROVIDERS) {

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTileLayerBasic.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTileLayerBasic.java
@@ -25,6 +25,8 @@ public class MapTileLayerBasic extends MapTileLayerArray implements IMapTileProv
         this.mContext = pContext;
         this.mMapView = mapView;
 
+        this.setTileRequestCompleteHandler(mMapView.getTileRequestCompleteHandler());
+
         final MapTileDownloader downloaderProvider =
                 new MapTileDownloader(pTileSource, mTileCache, mNetworkAvailabilityCheck, mMapView);
 


### PR DESCRIPTION
Asynchronous tile downloads were not  successful in calling the redraw of mapView.
This sometimes caused incorrect redrawing of tiles when working with tile overlays.

turns out it was just a missing assignment of SimpleInvalidationHandler