### PR TITLE
Tile loading performance improvements.

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTile.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/MapTile.java
@@ -42,7 +42,7 @@ public class MapTile implements GeoConstants, MapboxConstants, TileLayerConstant
         this.z = az;
         this.x = ax;
         this.y = ay;
-        this.path = String.format(MAPBOX_LOCALE, "%d/%d/%d", z, x, y);
+        this.path = (new StringBuilder()).append(z).append('/').append(x).append('/').append(y).toString();
         this.cacheKey = aCacheKey + "/" + path;
         this.code = ((17 * (37 + z)) * (37 * x)) * (37 + y);
     }

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/constants/TileLayerConstants.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/constants/TileLayerConstants.java
@@ -40,5 +40,5 @@ public interface TileLayerConstants {
      */
     public static final int NUMBER_OF_TILE_DOWNLOAD_THREADS = 8;
 
-    public static final int TILE_DOWNLOAD_MAXIMUM_QUEUE_SIZE = 40;
+    public static final int TILE_DOWNLOAD_MAXIMUM_QUEUE_SIZE = 8;
 }

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/util/MapboxUtils.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/util/MapboxUtils.java
@@ -114,7 +114,8 @@ public class MapboxUtils implements MapboxConstants {
     }
 
     public static String getMapTileURL(Context context, String mapID, int zoom, int x, int y, RasterImageQuality imageQuality) {
-        return String.format(MAPBOX_LOCALE, MAPBOX_BASE_URL_V4 + "%s/%d/%d/%d%s.%s?access_token=%s", mapID, zoom, x, y, "", MapboxUtils.qualityExtensionForImageQuality(imageQuality), MapboxUtils.getAccessToken());
+        return (new StringBuilder(MAPBOX_BASE_URL_V4)).append(mapID).append('/').append(zoom).append('/').append(x).append('/').append(y).append('.').
+                append(MapboxUtils.qualityExtensionForImageQuality(imageQuality)).append("?access_token=").append(MapboxUtils.getAccessToken()).toString();
     }
 
     /**


### PR DESCRIPTION
Quick win for now that requires testing across a number of devices to verify improvements work independently of screen sizes. Seems good on the Nexus 4 and S3 though.

* Improve tile loading performance during fast map interactions by using a smaller max queue size.

* Also, use stringbuilder for tile request performance improvements. Stolen mercilessly from https://github.com/mapbox/mapbox-android-sdk/pull/737 - so worth keeping an eye on if/when that PR gets merged.
