### PR TITLE
Fix for Issue 733

### DIFF
--- a/MapboxAndroidSDK/build.gradle
+++ b/MapboxAndroidSDK/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.2'
+        classpath 'com.android.tools.build:gradle:1.2.3'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.10.1'
     }
 }

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/WebSourceTileLayer.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/WebSourceTileLayer.java
@@ -140,6 +140,9 @@ public class WebSourceTileLayer extends TileLayer implements MapboxConstants {
 
             TileLoadedListener listener2 = downloader.getTileLoadedListener();
             if (listener2 != null) {
+                //create the CacheableBitmapDrawable object from the bitmap
+                result = cache.createCacheableBitmapDrawable(resultBitmap, aTile);
+                //pass it to onTileLoaded callback for customization, and return the customized CacheableBitmapDrawable object
                 result = listener2.onTileLoaded(result);
 
                 //convert the drawable updated in onTileLoaded callback to a bitmap

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/WebSourceTileLayer.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/WebSourceTileLayer.java
@@ -113,8 +113,9 @@ public class WebSourceTileLayer extends TileLayer implements MapboxConstants {
             String[] urls = getTileURLs(aTile, tempHDPI);
             CacheableBitmapDrawable result = null;
             Bitmap resultBitmap = null;
+            MapTileCache cache = downloader.getCache();
+
             if (urls != null) {
-                MapTileCache cache = downloader.getCache();
                 if (listener != null) {
                     listener.onTilesLoadStarted();
                 }
@@ -129,10 +130,7 @@ public class WebSourceTileLayer extends TileLayer implements MapboxConstants {
                         resultBitmap = compositeBitmaps(bitmap, resultBitmap);
                     }
                 }
-                if (resultBitmap != null) {
-                    //get drawable by putting it into cache (memory and disk)
-                    result = cache.putTileBitmap(aTile, resultBitmap);
-                }
+
                 if (checkThreadControl()) {
                     if (listener != null) {
                         listener.onTilesLoaded();
@@ -140,9 +138,22 @@ public class WebSourceTileLayer extends TileLayer implements MapboxConstants {
                 }
             }
 
-            if (result != null) {
-                TileLoadedListener listener2 = downloader.getTileLoadedListener();
-                result = listener2 != null ? listener2.onTileLoaded(result) : result;
+            TileLoadedListener listener2 = downloader.getTileLoadedListener();
+            if (listener2 != null) {
+                result = listener2.onTileLoaded(result);
+
+                //convert the drawable updated in onTileLoaded callback to a bitmap
+                Bitmap bitmapToCache = Bitmap.createBitmap(result.getIntrinsicWidth(), result.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+                Canvas canvas = new Canvas(bitmapToCache);
+                result.setBounds(0, 0, result.getIntrinsicWidth(), result.getIntrinsicHeight());
+                result.draw(canvas);
+
+                cache.putTileBitmap(aTile, bitmapToCache);
+            } else {
+                if (resultBitmap != null) {
+                    //get drawable by putting it into cache (memory and disk)
+                    result = cache.putTileBitmap(aTile, resultBitmap);
+                }
             }
 
             return result;

--- a/MapboxAndroidSDKTestApp/build.gradle
+++ b/MapboxAndroidSDKTestApp/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.2'
+        classpath 'com.android.tools.build:gradle:1.2.3'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.10.1'
     }
 }


### PR DESCRIPTION
After the discussion with @farfromrefug, I come up with this fix to avoid feeding redundant copies of CacheableBitmapDrawable to the cache.