### PR TITLE
fixes issue where no markers could be added after overlays have been cleared

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -405,6 +405,9 @@ public class MapView extends ViewGroup implements MapViewConstants, MapEventsRec
             defaultMarkerList.add(marker);
             setDefaultItemizedOverlay();
         } else {
+            if(!getOverlays().contains(defaultMarkerOverlay)){
+                addItemizedOverlay(defaultMarkerOverlay);
+            }
             defaultMarkerOverlay.addItem(marker);
         }
         marker.addTo(this);
@@ -419,6 +422,9 @@ public class MapView extends ViewGroup implements MapViewConstants, MapEventsRec
             defaultMarkerList.addAll(markers);
             setDefaultItemizedOverlay();
         } else {
+            if(!getOverlays().contains(defaultMarkerOverlay)){
+                addItemizedOverlay(defaultMarkerOverlay);
+            }
             defaultMarkerOverlay.addItems(markers);
         }
         for (Marker marker : markers) {


### PR DESCRIPTION
Issue:
When calling `mapview.getOverlays().clear()` also the `defaultMarkerOverlay` gets removed from the overlays list. Therefore Markers added after an overlay clear won't be displayed.

Fix:
When a marker is added, it is checked if the `defaultMarkerOverlay` is already added to the overlay list and if not it is added again