### PR TITLE
Remove examples map IDs

### DIFF
--- a/MapboxAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/android/testapp/MainTestFragment.java
+++ b/MapboxAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/android/testapp/MainTestFragment.java
@@ -29,9 +29,9 @@ import com.mapbox.mapboxsdk.views.util.TilesLoadedListener;
 public class MainTestFragment extends Fragment {
     private LatLng startingPoint = new LatLng(51f, 0f);
     private MapView mv;
-    private String satellite = "brunosan.map-cyglrrfu";
-    private String street = "examples.map-i87786ca";
-    private String terrain = "examples.map-zgrqqx0w";
+    private String satellite = "mapbox.satellite";
+    private String street = "mapbox.streets";
+    private String terrain = "mapbox.outdoors";
     private String currentLayer = "";
 
     @Override

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -56,7 +56,7 @@ a [ZXY image template](http://wiki.openstreetmap.org/wiki/Slippy_map_tilenames).
 ```java
 MapView mapView = new MapView(context);
 mapView.setAccessToken("Your Mapbox Access Token");
-mapView.setTileSource(new MapboxTileLayer("examples.map-vyofok3q"));
+mapView.setTileSource(new MapboxTileLayer("mapbox.streets"));
 ```
 
 And set it as the current view like this:

--- a/_config.mb-pages.yml
+++ b/_config.mb-pages.yml
@@ -7,6 +7,6 @@ baseurl: /mapbox-android-sdk
 highlighter: pygments
 version: 0.7.0
 snapshot: 0.7.1-SNAPSHOT
-defaultid: 'examples.map-i86nkdio'
+defaultid: 'mapbox.streets'
 rdiscount:
   extensions: [smart]

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,6 @@ baseurl: /mapbox-android-sdk
 highlighter: pygments
 version: 0.7.0
 snapshot: 0.7.1-SNAPSHOT
-defaultid: 'examples.map-i86nkdio'
+defaultid: 'mapbox.streets'
 rdiscount:
   extensions: [smart]

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 layout: pages
 category: overview
 title: Mapbox Android SDK
-mapid: examples.map-i86nkdio
+mapid: mapbox.streets
 navigation:
 - title: Installation
   items:
@@ -254,7 +254,7 @@ this.findViewById(R.id.mapview);
 {% highlight java %}
 MapView mapView = new MapView(context);
 mapView.setAccessToken("Your Mapbox Access Token");
-mapView.setTileSource(new MapboxTileLayer("examples.map-vyofok3q"));
+mapView.setTileSource(new MapboxTileLayer("mapbox.streets"));
 {% endhighlight %}
 
 And set it as the current view like this:


### PR DESCRIPTION
Removes all `examples` map IDs and replaces them with `mapbox` map IDs. cc @bleege 