### PR TITLE
Add "DoubleTapMap" to the MapViewListener

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -658,6 +658,16 @@ public class MapView extends ViewGroup implements MapViewConstants, MapEventsRec
         }
     }
 
+    public void onDoubleTap(final ILatLng p) {
+        if (mMapViewListener != null) {
+            mMapViewListener.onDoubleTapMap(MapView.this, p);
+        }
+        else
+        {
+            this.zoomInFixing(p, false);
+        }
+    }
+
     /**
      * Returns the map's controller
      */

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapViewGestureDetectorListener.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapViewGestureDetectorListener.java
@@ -93,7 +93,9 @@ public class MapViewGestureDetectorListener extends SimpleOnGestureListener {
         if (this.mapView.getOverlayManager().onDoubleTap(e, this.mapView)) {
             return true;
         }
-        final ILatLng center = this.mapView.getProjection().fromPixels(e.getX(), e.getY());
-        return this.mapView.zoomInFixing(center, false);
+
+        final ILatLng position = this.mapView.getProjection().fromPixels(e.getX(), e.getY());
+        this.mapView.onDoubleTap(position);
+        return true;
     }
 }

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapViewListener.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapViewListener.java
@@ -14,5 +14,7 @@ public interface MapViewListener {
 
     public void onTapMap(final MapView pMapView, final ILatLng pPosition);
 
+    public void onDoubleTapMap(final MapView pMapView, final ILatLng pPosition);
+
     public void onLongPressMap(final MapView pMapView, final ILatLng pPosition);
 }

--- a/MapboxAndroidSDK/src/main/java/com/spatialdev/osm/OSMMap.java
+++ b/MapboxAndroidSDK/src/main/java/com/spatialdev/osm/OSMMap.java
@@ -102,6 +102,11 @@ public class OSMMap implements MapViewListener, MapListener {
         }
     }
 
+    @Override
+    public void onDoubleTapMap(MapView pMapView, ILatLng pPosition) {
+
+    }
+
     private void drawDebugTapEnvelope(MapView pMapView, ILatLng pPosition, float zoom) {
         Envelope env = jtsModel.createTapEnvelope(pPosition, zoom);
         PathOverlay path;

--- a/MapboxAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/android/testapp/DraggableMarkersTestFragment.java
+++ b/MapboxAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/android/testapp/DraggableMarkersTestFragment.java
@@ -117,6 +117,11 @@ public class DraggableMarkersTestFragment extends Fragment
         }
 
         @Override
+        public void onDoubleTapMap(MapView mapView, ILatLng iLatLng) {
+
+        }
+
+        @Override
         public void onLongPressMap(MapView mapView, ILatLng iLatLng) {
 
         }

--- a/MapboxAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/android/testapp/RotatedMapTestFragment.java
+++ b/MapboxAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/android/testapp/RotatedMapTestFragment.java
@@ -62,6 +62,9 @@ public class RotatedMapTestFragment extends Fragment {
             }
 
             @Override
+            public void onDoubleTapMap(MapView mapView, ILatLng iLatLng) {}
+
+            @Override
             public void onLongPressMap(MapView pMapView, ILatLng pPosition) {}
         });
 

--- a/MapboxAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/android/testapp/TapForUTFGridTestFragment.java
+++ b/MapboxAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/android/testapp/TapForUTFGridTestFragment.java
@@ -46,6 +46,9 @@ public class TapForUTFGridTestFragment extends Fragment {
             }
 
             @Override
+            public void onDoubleTapMap(MapView mapView, ILatLng iLatLng) {}
+
+            @Override
             public void onLongPressMap(MapView pMapView, ILatLng pPosition) {}
         });
 


### PR DESCRIPTION
Enable the developers to override the default behavior. If the MapViewListener is not set, the double tap still zoom in.